### PR TITLE
Correctly set the API object on list responses

### DIFF
--- a/lists.go
+++ b/lists.go
@@ -125,8 +125,8 @@ func (api API) GetLists(params *ListQueryParams) (*ListOfLists, error) {
 		return nil, err
 	}
 
-	for _, l := range response.Lists {
-		l.api = &api
+	for i, _ := range response.Lists {
+		response.Lists[i].api = &api
 	}
 
 	return response, nil


### PR DESCRIPTION
Fix bug associating API structs with list responses.