### PR TITLE
Change type of ID on the Segment struct

### DIFF
--- a/segments.go
+++ b/segments.go
@@ -23,7 +23,7 @@ type SegmentRequest struct {
 type Segment struct {
 	SegmentRequest
 
-	ID          string `json:"id"`
+	ID          int `json:"id"`
 	MemberCount int    `json:"member_count"`
 	Type        string `json:"type"`
 	CreatedAt   string `json:"created_at"`


### PR DESCRIPTION
For now ID have a string type which is return error
```
json: cannot unmarshal number into Go struct field Segment.id of type string
```

After fixing it to the `int` it working fine